### PR TITLE
Add MV3 extension boilerplate

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "MV3 Boilerplate",
+  "version": "1.0.0",
+  "background": {
+    "service_worker": "src/background/index.js"
+  },
+  "action": {
+    "default_popup": "src/ui/popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://www.amazon.com/*"],
+      "js": ["src/content/amazon.js"]
+    },
+    {
+      "matches": ["*://www.ebay.com/*"],
+      "js": ["src/content/ebay.js"]
+    }
+  ]
+}

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/extension/src/content/amazon.ts
+++ b/extension/src/content/amazon.ts
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/extension/src/content/ebay.ts
+++ b/extension/src/content/ebay.ts
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/extension/src/ui/popup.html
+++ b/extension/src/ui/popup.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script type="module" src="./popup.js"></script>
+  </body>
+</html>

--- a/extension/src/ui/popup.ts
+++ b/extension/src/ui/popup.ts
@@ -1,0 +1,1 @@
+console.log('hello');


### PR DESCRIPTION
## Summary
- add Manifest V3 boilerplate with background, popup, and content scripts
- log "hello" from background, popup, and Amazon/eBay content scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a93d6a05e8832988317b36ee78b930